### PR TITLE
feat: emulate the r2 locally

### DIFF
--- a/src/app/dev_only/r2/[[...key]]/route.ts
+++ b/src/app/dev_only/r2/[[...key]]/route.ts
@@ -1,0 +1,69 @@
+/**
+ * R2 Storage Emulation for Development Environment
+ *
+ * This route provides local R2 storage emulation to ease development workflow.
+ * It's only available in development mode and is excluded from production builds.
+ *
+ * It mimics Cloudflare R2 storage behavior by allowing file retrieval through URL paths.
+ * Files are accessed via path segments defined in the dynamic route parameters.
+ *
+ * Example usage: /dev/r2/images/profile.jpg would retrieve the file at key path "images/profile.jpg"
+ */
+
+import { getContentTypeFromExtension } from "@/utils/content-type";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+/**
+ * GET handler for R2 file retrieval
+ *
+ * This function processes incoming requests for files stored in the R2 storage.
+ * It extracts the file path from the URL segments, retrieves the file from storage,
+ * and returns it with the appropriate content type headers.
+ *
+ * @param request - The incoming HTTP request object
+ * @param params - The dynamic route parameters containing the file path segments
+ * @returns Response with file data or appropriate error message (404, 503)
+ */
+export async function GET(
+  _: Request,
+  { params }: { params: Promise<{ key: string[] }> }
+) {
+  if (process.env.NODE_ENV !== "development") {
+    return new Response("R2 emulation is only available in development mode.", {
+      status: 503, // Service Unavailable
+    });
+  }
+
+  // Extract and join the path segments to form the complete file key path
+  const { key } = await params;
+  const keyPath = key.join("/");
+
+  // Get Cloudflare environment bindings for accessing R2 storage
+  const { env } = getCloudflareContext();
+
+  // Check if R2 bucket is available in the current environment
+  // USER_UPLOADS is our R2 bucket binding defined in wrangler.toml
+  if (!env.USER_UPLOADS) {
+    return new Response("R2 emulation is not available in this environment.", {
+      status: 503, // Service Unavailable
+    });
+  }
+
+  // Attempt to retrieve the file from R2 storage using the constructed key path
+  const file = await env.USER_UPLOADS.get(keyPath);
+
+  // Return 404 if the requested file doesn't exist in the R2 bucket
+  if (!file) {
+    return new Response("File not found", { status: 404 });
+  }
+
+  const extension = keyPath.split(".").pop()?.toLowerCase();
+
+  // Return the file with appropriate headers for proper browser rendering
+  return new Response(file.body, {
+    headers: {
+      "Content-Type": getContentTypeFromExtension(extension ?? ""),
+      "Content-Length": file.size.toString(),
+    },
+  });
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,9 @@
+export const BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:3000"
+    : "https://khmercoder.com";
+
+export const USER_UPLOAD_URL =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:3000/dev_only/r2"
+    : "https://cdn.khmercoder.com";

--- a/src/utils/content-type.ts
+++ b/src/utils/content-type.ts
@@ -1,0 +1,18 @@
+const extensionToMimeType: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  zip: "application/zip",
+  rar: "application/x-rar-compressed",
+  tar: "application/x-tar",
+  gz: "application/gzip",
+  pdf: "application/pdf",
+};
+
+export function getContentTypeFromExtension(extension: string): string {
+  return (
+    extensionToMimeType[extension.toLowerCase()] || "application/octet-stream"
+  );
+}


### PR DESCRIPTION
This PR introduces a local emulation of R2, allowing developers to test file uploads and preview files as if they were stored in the real R2 service. 

This significantly reduces setup complexity and speeds up development by removing the need to configure and connect to an actual R2 instance during local testing.