### PR TITLE
Refactor experience actions and add sorting utility with tests

### DIFF
--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -8,6 +8,7 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { UserLevelBadge } from '@/components/user-level-badge';
 import { ProfileTrackingComponent } from './tracker';
+import { sortExperience } from '@/utils/experience';
 
 export async function generateMetadata({
   params,
@@ -89,11 +90,13 @@ export default async function UserProfilePage({
   if (!profile) {
     return notFound();
   } // Getting the experience
-  const experiences = await db
-    .select()
-    .from(schema.workExperience)
-    .where(eq(schema.workExperience.userId, profile.user.id))
-    .orderBy(desc(schema.workExperience.endYear), desc(schema.workExperience.startYear));
+
+  const experiences = sortExperience(
+    await db
+      .select()
+      .from(schema.workExperience)
+      .where(eq(schema.workExperience.userId, profile.user.id))
+  );
 
   return (
     <>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 // Founder Card Component with detailed bio
 
-import { DrizzleD1Database } from "drizzle-orm/d1";
-import * as schema from "@/libs/db/schema";
+import { DrizzleD1Database } from 'drizzle-orm/d1';
+import * as schema from '@/libs/db/schema';
 
 // Define the type for the member object
 export interface ITeamMember {
@@ -66,3 +66,4 @@ export enum UserLevel {
 
 export type MainDatabase = DrizzleD1Database<typeof schema>;
 export type UserRecord = typeof schema.user.$inferSelect;
+export type ExperienceRecord = typeof schema.workExperience.$inferSelect;

--- a/src/utils/experience.test.ts
+++ b/src/utils/experience.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest';
+import { sortExperience } from './experience';
+import { ExperienceRecord } from '@/types';
+
+test('ordering working experience with present', () => {
+  const exp = sortExperience([
+    e('Company A', 2020, 2022),
+    e('Company B', 2019, null), // Present
+    e('Company C', 2021, 2023),
+    e('Company D', 2018, null), // Present
+    e('Company E', 2022, null), // Present
+  ]);
+
+  expect(exp[0].companyName).toEqual('Company E'); // Most recent present experience
+  expect(exp[1].companyName).toEqual('Company B'); // Second most recent present experience
+  expect(exp[2].companyName).toEqual('Company D'); // Most recent past experience
+  expect(exp[3].companyName).toEqual('Company C'); // Second most recent past experience
+  expect(exp[4].companyName).toEqual('Company A'); // Oldest present experience
+});
+
+test('ordering working experience with all past', () => {
+  const exp = sortExperience([
+    e('Company A', 2020, 2022),
+    e('Company B', 2019, 2021),
+    e('Company C', 2021, 2023),
+    e('Company D', 2018, 2020),
+    e('Company E', 2022, 2023),
+  ]);
+
+  expect(exp[0].companyName).toEqual('Company E'); // Most recent past experience
+  expect(exp[1].companyName).toEqual('Company C'); // Second most recent past experience
+  expect(exp[2].companyName).toEqual('Company A'); // Third most recent past experience
+  expect(exp[3].companyName).toEqual('Company B'); // Fourth most recent past experience
+  expect(exp[4].companyName).toEqual('Company D'); // Oldest past experience
+});
+
+/**
+ * Helper function to create an experience record.
+ * This is used to generate test data for the sorting function.
+ */
+function e(companyName: string, startYear: number, endYear: number | null): ExperienceRecord {
+  return {
+    id: companyName,
+    companyName,
+    startYear,
+    endYear,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    role: '',
+    description: '',
+    companyId: null,
+    userId: '',
+    companyLogo: '',
+  };
+}

--- a/src/utils/experience.ts
+++ b/src/utils/experience.ts
@@ -1,0 +1,23 @@
+import type { ExperienceRecord } from '@/types';
+
+/**
+ * Sorting experience record by end date in descending order.
+ * If end date is NULL, it means it is present, so it should be sorted to the top.
+ * Using start date as tie-breaker in descending order.
+ *
+ * @param experiences
+ * @returns
+ */
+export function sortExperience(experiences: ExperienceRecord[]): ExperienceRecord[] {
+  return experiences.sort((a, b) => {
+    // Handle cases where end date is NULL
+    const endA = a.endYear || 9999;
+    const endB = b.endYear || 9999;
+
+    // Compare end dates first
+    if (endA < endB) return 1; // b comes before a
+    if (endA > endB) return -1; // a comes before b
+
+    return b.startYear - a.startYear; // Sort by start date in descending order
+  });
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,6 @@
 export function formatSize(bytes: number): string {
-  const sizes = ["B", "KB", "MB", "GB", "TB"];
-  if (bytes === 0) return "0B";
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  if (bytes === 0) return '0B';
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   return `${(bytes / Math.pow(1024, i)).toFixed(2)}${sizes[i]}`;
 }


### PR DESCRIPTION
Sorting experience record by end date in descending order. If end date is NULL, it means it is present, so it should be sorted to the top. Using start date as tie-breaker in descending order.
