### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,71 @@
+# Written by @manethpak
+
+name: 🐛 Bug Report
+description: Problems and issues with the project.
+title: 'Bug Report: '
+labels: ['type: bug']
+body:
+  - type: markdown
+    attributes:
+      value: 'Please provide a summary of the issue in the title above ⬆️.'
+
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: Please provide as much information as possible regarding the problem.
+      placeholder: >
+        Please provide the context in which the problem occur, along with a video or screenshot if possible, it will be extremely helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What expected to happen
+      description: What do you think went wrong?
+      placeholder: >
+        Please explain why you think the behaviour is wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Step to reproduce
+      description: >
+        What should we do to reproduce the problem?
+      placeholder: >
+        Please provide a reproducible step-by-step case of how to reproduce the problem as minimally and precisely as possible.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Version
+      description: >
+        In which version of the project does this problem occur?
+
+  - type: textarea
+    attributes:
+      label: Environment
+      description: Please describe the enviroment which the problem occur.
+      placeholder: >
+        Node version:
+        Docker version:
+        OS platform:
+        OS version:
+
+  - type: dropdown
+    attributes:
+      label: Are you willing to fix the bug?
+      description: Select the option that best describes your willingness to fix the bug.
+      multiple: false
+      options:
+        - "Yes, I'm willing to fix the bug"
+        - "No, I'm just reporting the bug"
+
+  - type: markdown
+    attributes:
+      value: <br>
+
+  - type: markdown
+    attributes:
+      value: By submitting this issue I agree to follow this project's [Code of Conduct]()

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,0 +1,24 @@
+# Written by @manethpak
+
+name: 📚 Documentation Report
+description: Submit a problem or an enhancement for the documentation.
+title: 'Docs Report: '
+labels: ['type: documentation']
+body:
+  - type: markdown
+    attributes:
+      value: 'Please provide a summary of the issue in the title above ⬆️.'
+
+  - type: textarea
+    attributes:
+      label: Problem with the current documentation
+      description: Describe the issue you're having with the documentation.
+      placeholder: >
+        If you're having trouble with a specific part of the documentation, please provide a link to the specific section. Explain why is it an issue.
+
+  - type: textarea
+    attributes:
+      label: Suggested improvement
+      description: Describe the improvement you'd like to see.
+      placeholder: >
+        How can we improve the documentation? What should we add? What should we remove? What should we change? If you have a specific solution or suggestion in mind, feel free to include it.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+# Written by @manethpak
+
+name: 🙇 Feature Request
+description: Submit a proposal for a new feature
+title: 'Feature Request: '
+labels: ['type: feature request']
+body:
+  - type: markdown
+    attributes:
+      value: 'Please provide a summary of the issue in the title above ⬆️.'
+
+  - type: textarea
+    attributes:
+      label: Summary 📝
+      description: Describe your feature proposal. What would it do? How would it work?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Example Use Cases 🥸
+      description: Describe the detail of the use cases of this proposal. What would it be used for?
+
+  - type: textarea
+    attributes:
+      label: Motivation 🔦
+      description: Describe the motivation of this proposal, Why it is needed? How will it affect the user or the project?
+
+  - type: dropdown
+    attributes:
+      label: Are you willing to implement the feature? 🥺
+      description: Select the option that best describes your willingness to implement the feature.
+      multiple: false
+      options:
+        - "Yes, I'm willing to implement the feature"
+        - "No, I'm just making a suggestion"
+
+  - type: markdown
+    attributes:
+      value: <br>
+
+  - type: markdown
+    attributes:
+      value: By submitting this issue I agree to follow this project`s [Code of Conduct]()


### PR DESCRIPTION
Add GitHub Issue Templates, the templates will help contributors provide necessary information upfront, making it easier to understand and handle issues.

Added templates:
- Bug report: For reporting bugs with reproduction steps
- Feature request: For suggesting new features or improvement
- Doc report: For reporting problem or suggesting improvement for the documentation 


