### PR TITLE
[#44]: Add View Button for Images

### DIFF
--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -15,7 +15,7 @@ import { formatAgo, formatSize } from '@/utils/format';
 import { renderIconFromContentType } from '@/utils/icons';
 import { Button } from '@/components/generated/button';
 import { useUserUpload } from '@/components/user-upload/context';
-import { Copy, Ellipsis, Trash } from 'lucide-react';
+import { Copy, Ellipsis, Trash, Eye } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -156,6 +156,14 @@ function FileTable({ files }: { files: UserUploadRecordWithBinding[] }) {
                     <Ellipsis className="w-4 h-4" />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent side="bottom" align="start">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        window.open(file.fileUrl, '_blank');
+                      }}
+                    >
+                      <Eye />
+                      View file
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                       onSelect={() => {
                         navigator.clipboard.writeText(file.fileUrl);


### PR DESCRIPTION
Closes #44

## Proposed Changes

  -  Add View file button in Image storage

## Screenshot 

<img width="1326" alt="Screenshot 2025-07-01 at 11 41 26 pm" src="https://github.com/user-attachments/assets/83f98451-9747-4c4b-b6c6-1d44446f11d9" />

