### PR TITLE
[#66]: Article detail datetime display incorrect timezone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "clsx": "^2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "4.1.0",
+        "date-fns-tz": "^3.2.0",
         "drizzle-orm": "^0.41.0",
         "embla-carousel-react": "8.5.2",
         "immer": "^10.1.1",
@@ -15839,6 +15840,15 @@
       "version": "4.1.0-0",
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "clsx": "^2.1.1",
     "cmdk": "1.1.1",
     "date-fns": "4.1.0",
+    "date-fns-tz": "^3.2.0",
     "drizzle-orm": "^0.41.0",
     "embla-carousel-react": "8.5.2",
     "immer": "^10.1.1",

--- a/src/components/article-item.tsx
+++ b/src/components/article-item.tsx
@@ -18,6 +18,7 @@ import { CommentButton, LikeButton } from './interaction-button';
 import { useSession } from './auth-provider';
 import { MODERATOR_ACCESS } from '@/constants';
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 interface ArticlePreviewItemProps {
   data: ArticlePreviewRecord;
@@ -52,8 +53,17 @@ export function ArticlePreviewItem({ data, showControlPanel }: ArticlePreviewIte
             <div className="text-xs text-muted-foreground">
               {data.createdAt && (
                 <time suppressHydrationWarning>
-                  {format(new Date(data.createdAt), 'MMM d, yyyy')} at{' '}
-                  {format(new Date(data.createdAt), 'h:mm a')}
+                  {formatInTimeZone(
+                    new Date(data.createdAt),
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'MMM d, yyyy'
+                  )}{' '}
+                  at{' '}
+                  {formatInTimeZone(
+                    new Date(data.createdAt),
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    'h:mm a'
+                  )}
                 </time>
               )}
 

--- a/src/components/article-item.tsx
+++ b/src/components/article-item.tsx
@@ -17,6 +17,7 @@ import Image from 'next/image';
 import { CommentButton, LikeButton } from './interaction-button';
 import { useSession } from './auth-provider';
 import { MODERATOR_ACCESS } from '@/constants';
+import { format } from 'date-fns';
 
 interface ArticlePreviewItemProps {
   data: ArticlePreviewRecord;
@@ -51,16 +52,8 @@ export function ArticlePreviewItem({ data, showControlPanel }: ArticlePreviewIte
             <div className="text-xs text-muted-foreground">
               {data.createdAt && (
                 <time suppressHydrationWarning>
-                  {new Date(data.createdAt).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}{' '}
-                  at{' '}
-                  {new Date(data.createdAt).toLocaleTimeString('en-US', {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })}
+                  {format(new Date(data.createdAt), 'MMM d, yyyy')} at{' '}
+                  {format(new Date(data.createdAt), 'h:mm a')}
                 </time>
               )}
 


### PR DESCRIPTION
Closes #66

## Proposed Changes

  - Use datefns to format it should use localTimeZone by default
  - Use datefns timezone to guess user's local timezone