### PR TITLE
Improve the article editor and improve its error message

### DIFF
--- a/src/app/profile/articles/[articleId]/page-client.tsx
+++ b/src/app/profile/articles/[articleId]/page-client.tsx
@@ -61,8 +61,13 @@ export function ArticleEditClientPage({ data }: ArticleEditClientPageProps) {
     }) => {
       setSubmitting(true);
       const result = await updateArticleAction(id, data);
-      if (published) {
-        await updateArticlePublishAction(result.id, true);
+
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      if (published && result.updatedArticle) {
+        await updateArticlePublishAction(result.updatedArticle.id, true);
       }
       setSubmitting(false);
       return result;
@@ -86,7 +91,11 @@ export function ArticleEditClientPage({ data }: ArticleEditClientPageProps) {
         errorMessage={error?.message}
         isUpdate
       />
-      <ArticleEditor onChange={setValue} value={value} />
+
+      <div className="bg-card max-w-5xl p-4 container mx-auto border rounded">
+        <ArticleEditor onChange={setValue} value={value} />
+      </div>
+
       <AlertDialog open={navGuard.active}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/src/app/profile/articles/components/ArticleEditor.tsx
+++ b/src/app/profile/articles/components/ArticleEditor.tsx
@@ -77,7 +77,7 @@ export function ArticleEditor({ value, onChange }: ArticleEditorProps) {
   );
 
   return (
-    <div className="max-w-4xl mx-auto my-4 mb-12">
+    <div>
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <Label>Title</Label>

--- a/src/app/profile/articles/components/ArticleEditorHeader.tsx
+++ b/src/app/profile/articles/components/ArticleEditorHeader.tsx
@@ -19,7 +19,7 @@ export function ArticleEditorHeader({
   return (
     <>
       <div className="border-b p-4 mb-8 -mt-4">
-        <div className="max-w-4xl mx-auto flex items-center">
+        <div className="max-w-5xl mx-auto flex items-center">
           <h1 className="font-bold grow">{isUpdate ? 'Update Article' : 'Create Article'}</h1>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -36,7 +36,7 @@ export function ArticleEditorHeader({
       {errorMessage && (
         <div className="max-w-4xl mx-auto mb-4">
           <div className="bg-red-100 text-red-800 p-4 rounded">
-            <p className="text-sm">{errorMessage}</p>
+            <pre className="text-sm">{errorMessage}</pre>
           </div>
         </div>
       )}

--- a/src/app/profile/articles/create/page.tsx
+++ b/src/app/profile/articles/create/page.tsx
@@ -59,13 +59,22 @@ export default function BlogPage() {
     }) => {
       setSubmitting(true);
       const result = await createArticleAction(data);
+
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      if (!result.article) {
+        throw new Error('Failed to create article');
+      }
+
       if (published) {
-        await updateArticlePublishAction(result.id, true);
+        await updateArticlePublishAction(result.article.id, true);
       }
       // Clear unsaved changes flag after successful save
       hasUnsavedChangesRef.current = false;
       setSubmitting(false);
-      return result;
+      return result.article;
     },
     onSuccess: data => {
       console.log('Article created successfully:', data);
@@ -89,7 +98,10 @@ export default function BlogPage() {
         loading={isPending}
         errorMessage={error?.message}
       />
-      <ArticleEditor onChange={setValue} value={value} />
+
+      <div className="bg-card max-w-5xl p-4 container mx-auto border rounded">
+        <ArticleEditor onChange={setValue} value={value} />
+      </div>
 
       <AlertDialog open={navGuard.active}>
         <AlertDialogContent>

--- a/src/components/markdown-editor/index.tsx
+++ b/src/components/markdown-editor/index.tsx
@@ -21,10 +21,35 @@ export function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
   const [fullscreen, setFullscreen] = useState(false);
   const editorRef = useRef<ReactCodeMirrorRef>(null);
   const debounceValue = useDebounce(value, 100);
-  const extensions = useMemo(() => {
-    return [markdown(), EditorView.lineWrapping];
-  }, []);
   const { resolvedTheme } = useTheme();
+
+  const extensions = useMemo(() => {
+    const baseExtensions = [markdown(), EditorView.lineWrapping];
+
+    if (resolvedTheme === 'dark') {
+      // Custom theme for black background in dark mode
+      const darkTheme = EditorView.theme(
+        {
+          '&': {
+            backgroundColor: '#000000',
+            color: '#ffffff',
+          },
+          '.cm-content': {
+            backgroundColor: '#000000',
+            color: '#ffffff',
+          },
+          '.cm-selectionBackground': {
+            backgroundColor: '#00bfa640',
+          },
+        },
+        { dark: true }
+      );
+
+      baseExtensions.push(darkTheme);
+    }
+
+    return baseExtensions;
+  }, [resolvedTheme]);
 
   useEffect(() => {
     getMarkdownImageUrls(debounceValue).then(console.log);
@@ -85,7 +110,7 @@ export function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
           }}
         >
           <Fullscreen className="w-4 h-4" />
-          Preview
+          {fullscreen ? 'Exit Preview' : 'Preview'}
         </Button>
       </div>
       <div className="flex grow overflow-hidden bg-card">
@@ -96,8 +121,9 @@ export function MarkdownEditor({ value, onChange }: MarkdownEditorProps) {
           basicSetup={{
             lineNumbers: false,
             foldGutter: false,
+            drawSelection: false,
           }}
-          theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
+          theme={resolvedTheme === 'dark' ? undefined : 'light'}
           extensions={extensions}
           value={value}
           onChange={onChange}


### PR DESCRIPTION
One of the most common errors when submitting an article is including images that don't belong to the user. Previously, the error message was too generic and didn't help identify the problem. This PR improves that by clearly indicating which image in the markdown does not belong to the user.

Additionally, this PR improves the article editor interface for light mode.

<img width="1216" height="680" alt="image" src="https://github.com/user-attachments/assets/de32d3f8-1518-41f7-ace8-76f9b51e7ccb" />
