### PR TITLE
Fix/header skicky

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
                   <div className="min-h-screen relative">
                     {/* Content container */}
                     <div className="relative">
-                      <header className=" sticky bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
+                      <header className="sticky top-0 z-50 bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
                         <Link href="/" className="flex items-center z-9999">
                           <Image
                             src="/khmer-coder.svg"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
                   <div className="min-h-screen relative">
                     {/* Content container */}
                     <div className="relative">
-                      <header className="bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
+                      <header className=" sticky bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
                         <Link href="/" className="flex items-center z-9999">
                           <Image
                             src="/khmer-coder.svg"


### PR DESCRIPTION
Make Navigation Bar **Sticky**
Added sticky top-0 z-50 classes to header element
fixed at the top of the page when users scroll down, providing better navigation experience.
<img width="1765" height="944" alt="image" src="https://github.com/user-attachments/assets/59f4b8a0-5d97-4d33-a0ab-dad9abb2346f" />

