### PR TITLE
Fixing overflow horizontally on website at medium breakpoint 

### DIFF
--- a/src/components/atoms/header.tsx
+++ b/src/components/atoms/header.tsx
@@ -10,7 +10,7 @@ export function Header() {
   const isHomePage = pathname === '/';
 
   return (
-    <header className="bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
+    <header className="bg-white dark:bg-black py-1 px-4 xl:px-16 flex items-center gap-2 lg:gap-12 mb-8 justify-between bg-background border-b shadow-[0_2px_8px_-1px_rgba(251,146,60,0.4)]">
       <Link href="/" className="flex items-center z-9999">
         <div className="w-14 h-14 flex items-center justify-center">
           <Image

--- a/src/components/atoms/nav-bar.tsx
+++ b/src/components/atoms/nav-bar.tsx
@@ -30,7 +30,7 @@ export const Navbar = () => {
 
   return (
     <div className="flex items-center flex-row">
-      <div className="flex gap-4 items-center sm:hidden">
+      <div className="flex gap-2 sm:gap-4 items-center md:hidden">
         <UserAvatar />
         <NavbarContainer className="items-center flex-row" aria-label="Mobile Navigation">
           <Sheet>
@@ -111,8 +111,8 @@ export const Navbar = () => {
           </Sheet>
         </NavbarContainer>
       </div>
-      <div className="hidden sm:flex gap-4 items-center">
-        <NavbarContainer aria-label="Main Navigation">
+      <div className="hidden md:flex gap-4 items-center">
+        <NavbarContainer isDesktop aria-label="Main Navigation">
           <NavbarLink href="/events" isHighlighted={isActiveLink('/events')}>
             Events
           </NavbarLink>
@@ -138,9 +138,19 @@ export const Navbar = () => {
 
 export default Navbar;
 
-export const NavbarContainer = ({ children, className, ...props }: ComponentProps<'nav'>) => {
+export const NavbarContainer = ({
+  children,
+  className,
+  isDesktop,
+  ...props
+}: ComponentProps<'nav'> & { isDesktop?: boolean }) => {
   return (
-    <nav className={cn('flex w-fit', className)} {...props}>
+    <nav
+      className={cn('flex w-fit', className, {
+        'md:[&_a]:text-[0.8125rem] md:[&_a]:sm:w-20 lg:[&_a]:text-sm lg:[&_a]:sm:w-28': isDesktop,
+      })}
+      {...props}
+    >
       <ul className="flex w-fit items-center justify-between">{children}</ul>
     </nav>
   );


### PR DESCRIPTION
## Based on this issue #76, I did change some styles to fix it by:

  - reducing `gap` on `<header>` element _(between `Logo` and `NavBar`)_
  - reducing `gap` on `<NavBar>` component for small screen (between `UserAvatar` and `NavBarContainer`)
  - hiding `burger menu` and show `navbar` on medium screen with smaller font size
  - adding `isDesktop` attribute to be **optional** to style `NavBarContainer` children differently

---

If there are any mistakes, I am happy to get corrected by bong bong, Thanks!