### PR TITLE
Bug Report: Wrong user name and alias displayed in sidebar

### DIFF
--- a/src/components/blocks/layout/UserProfileMenu.tsx
+++ b/src/components/blocks/layout/UserProfileMenu.tsx
@@ -31,8 +31,8 @@ export function UserProfileMenu() {
             <AvatarFallback>{user.name?.[0] || 'U'}</AvatarFallback>
           </Avatar>
           <div className="text-sm">
-            <p>Visal In</p>
-            <p className="text-muted-foreground">@invisal</p>
+            {user.name && <p>{user.name}</p>}
+            {profile && <p className="text-muted-foreground">@{profile.alias}</p>}
           </div>
         </button>
       </DropdownMenuTrigger>


### PR DESCRIPTION
Related #95 

## Proposed Changes

**Before:**
<img width="997" height="307" alt="image" src="https://github.com/user-attachments/assets/27687ec3-d2f6-4bae-b268-656196cad954" />

**After:**
<img width="827" height="287" alt="image" src="https://github.com/user-attachments/assets/be8273ce-f1fc-4ee0-ae68-6bbdee940551" />
