### PR TITLE
fix: await params in generateMetadata and EventDetailPage for correct…

### DIFF
--- a/src/app/events/[alias]/page.tsx
+++ b/src/app/events/[alias]/page.tsx
@@ -21,7 +21,8 @@ export async function generateMetadata({
 }: {
   params: { alias: string };
 }): Promise<Metadata> {
-  const event = eventsDatabase.find(event => event.id === params.alias);
+  const awaitedParams = await params;
+  const event = eventsDatabase.find(event => event.id === awaitedParams.alias);
 
   if (!event) {
     return {
@@ -48,7 +49,9 @@ export async function generateMetadata({
   };
 }
 
-export default function EventDetailPage({ params: { alias } }: { params: { alias: string } }) {
+export default async function EventDetailPage({ params }: { params: { alias: string } }) {
+  const awaitedParams = await params;
+  const { alias } = awaitedParams;
   const event = eventsDatabase.find(event => event.id === alias);
 
   if (!event) {


### PR DESCRIPTION
## Fix: Await `params` in Dynamic Route `/events/[alias]` (Next.js 14+)
<img width="1535" height="287" alt="image" src="https://github.com/user-attachments/assets/d8092b80-70e6-48bb-a1a6-9e70f3f3e19f" />

### Problem

Next.js 14+ requires that dynamic route parameters (`params`) be awaited before accessing their properties. The previous implementation accessed `params.alias` directly, causing the following error:

```
Error: Route "/events/[alias]" used `params.alias`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
```

### Solution

- Updated both `generateMetadata` and the default export `EventDetailPage` to:
  - Await the `params` object before destructuring or accessing its properties.
  - Use the awaited value to safely access `alias`.

#### Example Change

```tsx
// Before
export default async function EventDetailPage({ params }: { params: { alias: string } }) {
  const { alias } = params;
  // ...
}

// After
export default async function EventDetailPage({ params }: { params: { alias: string } }) {
  const awaitedParams = await params;
  const { alias } = awaitedParams;
  // ...
}
```
<img width="707" height="244" alt="image" src="https://github.com/user-attachments/assets/70d4ec21-857d-47a1-b40d-a42e4c2017b9" />

### Why

- This change ensures compatibility with Next.js 14+ dynamic route API.
- Prevents runtime errors and improves route stability.

---

**Tested:**  
- Navigated to `/events/[alias]` routes and confirmed no runtime errors.
- Metadata generation works as expected.

