### PR TITLE
feat: Add mobile safe area support and update layout components for b…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,18 @@ based on light & dark themes */
   --breakpoint-lg: 80rem;
 }
 
+/* Mobile safe areas and viewport units for handling browser UI */
+@supports (padding: env(safe-area-inset-bottom)) {
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
+/* Fallback for browsers that don't support env() */
+.pb-safe {
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,16 +33,18 @@ based on light & dark themes */
 }
 
 /* Mobile safe areas and viewport units for handling browser UI */
+/* Fallback for browsers that don't support env() */
+.pb-safe {
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+}
+
 @supports (padding: env(safe-area-inset-bottom)) {
   .pb-safe {
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
 
-/* Fallback for browsers that don't support env() */
-.pb-safe {
-  padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
-}
+/* end of mobile safe areas */
 
 @layer base {
   :root {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,10 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+        />
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,13 @@ import { ServerStatsProvider } from '@/components/contexts/ServerStatsContext';
 export const metadata = {
   title: "Khmer Coders - Cambodia's Largest Coding Community",
   description: "Join Cambodia's largest community of developers, designers, and tech enthusiasts.",
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: false,
+    viewportFit: 'cover',
+  },
 };
 
 export default async function RootLayout({
@@ -34,6 +41,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,10 +42,6 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
-        />
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,13 +12,14 @@ import { ServerStatsProvider } from '@/components/contexts/ServerStatsContext';
 export const metadata = {
   title: "Khmer Coders - Cambodia's Largest Coding Community",
   description: "Join Cambodia's largest community of developers, designers, and tech enthusiasts.",
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-    maximumScale: 1,
-    userScalable: false,
-    viewportFit: 'cover',
-  },
+};
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
 };
 
 export default async function RootLayout({

--- a/src/components/blocks/layout/MainLayout.tsx
+++ b/src/components/blocks/layout/MainLayout.tsx
@@ -11,7 +11,9 @@ export function MainLayout({
   return (
     <div className="mx-auto max-w-[1200px] flex min-h-screen">
       <DesktopLeftNavigation />
-      <div className="border-x grow overflow-hidden">{children}</div>
+      <div className="border-x grow overflow-hidden">
+        <div className="pb-20 md:pb-0">{children}</div>
+      </div>
       {!hideRightNav && <DesktopRightNavigation />}
       <MobileTabNavigation />
     </div>

--- a/src/components/blocks/layout/MobileTabNav.tsx
+++ b/src/components/blocks/layout/MobileTabNav.tsx
@@ -13,7 +13,7 @@ export function MobileTabNavigation() {
   const tabButtonClass = 'flex text-center p-3 items-center justify-center focus:outline-none';
 
   return (
-    <div className="md:hidden fixed bottom-0 left-0 w-screen bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 z-50">
+    <div className="md:hidden fixed bottom-0 left-0 w-screen bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 z-50 pb-safe">
       <nav className="grid grid-cols-4">
         <Link className={tabButtonClass} href="/">
           <HomeIcon />

--- a/src/components/blocks/post/CommentEditor.tsx
+++ b/src/components/blocks/post/CommentEditor.tsx
@@ -53,7 +53,7 @@ export function CommentEditor({
   });
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 mb-4 md:mb-0">
       {/* Hidden textarea for measuring height */}
       <textarea
         ref={hiddenTextareaRef}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -73,6 +73,12 @@ const config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      padding: {
+        'safe': 'max(0.75rem, env(safe-area-inset-bottom))',
+        'safe-top': 'max(0.75rem, env(safe-area-inset-top))',
+        'safe-left': 'max(0.75rem, env(safe-area-inset-left))',
+        'safe-right': 'max(0.75rem, env(safe-area-inset-right))',
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION

## Summary of Changes

### 1. **Added Bottom Padding to Main Content** (MainLayout.tsx)
- Added `pb-20 md:pb-0` class to provide 80px bottom padding on mobile only
- This ensures content doesn't get hidden behind the mobile navigation

### 2. **Enhanced Mobile Navigation** (MobileTabNav.tsx)
- Added `pb-safe` class to respect device safe areas
- The navigation bar now uses CSS environment variables to adapt to different mobile browsers

### 3. **Added CSS Safe Area Support** (globals.css)
- Added CSS environment variable support for `safe-area-inset-bottom`
- Provides fallback padding for browsers that don't support `env()`
- Uses `max()` function to ensure minimum padding while respecting safe areas

### 4. **Improved CommentEditor Spacing** (CommentEditor.tsx)
- Added `mb-4 md:mb-0` to provide extra bottom margin on mobile
- Ensures the submit button has proper spacing when it's the last element

### 5. **Enhanced Viewport Configuration** (layout.tsx)
- Added comprehensive viewport meta tag with `viewport-fit=cover`
- Configured metadata viewport settings
- Prevents zoom and enables proper safe area support

### 6. **Extended Tailwind Configuration** (tailwind.config.ts)
- Added safe area utilities (`p-safe`, `p-safe-top`, etc.)
- Uses CSS environment variables for dynamic padding based on device safe areas

## How This Fixes the Issue

The issue was that mobile browsers have a bottom navigation bar that covers content, and the app also has its own mobile navigation that adds to this problem. The fix:

1. **Prevents Double Overlap**: The padding accounts for both the browser's UI and the app's navigation
2. **Adapts to Different Devices**: Safe area support means it works correctly on different mobile devices and orientations
3. **Maintains Desktop Experience**: All mobile-specific changes are conditional and don't affect desktop users
4. **Future-Proof**: Uses modern CSS environment variables that will work with future mobile browser changes

The submit button in comment forms should now be fully visible and accessible on mobile devices, even when the browser's bottom navigation is visible.

<img width="571" height="865" alt="image" src="https://github.com/user-attachments/assets/50b0123a-8862-49cc-a807-4b6ee94bc8f7" />


Closes #98 