### PR TITLE
fix: remove unused fields from article query in UserArticleListPage

### DIFF
--- a/src/app/[username]/articles/page.tsx
+++ b/src/app/[username]/articles/page.tsx
@@ -38,12 +38,11 @@ export default async function UserArticleListPage({
         published: true,
         userId: true,
         likeCount: true,
-        banByUserId: true,
-        banReason: true,
         approvedByAI: true,
         commentCount: true,
-        isBanned: true,
         viewCount: true,
+        reviewStatus: true,
+        reviewBy: true,
       },
       with: {
         user: {

--- a/src/components/blocks/layout/NavigationRoute.ts
+++ b/src/components/blocks/layout/NavigationRoute.ts
@@ -48,9 +48,9 @@ export function useNavigationRoutes(): (NavigationRouteItem | '---')[] {
       icon: Package,
     },
     {
-      title: "Members",
+      title: 'Members',
       path: '/users',
-      icon: User
+      icon: User,
     },
     {
       title: 'Chatroom',

--- a/src/libs/db/schema.ts
+++ b/src/libs/db/schema.ts
@@ -8,33 +8,41 @@ import {
 import { desc, relations, sql } from 'drizzle-orm';
 import { sqliteTable, text, integer, index, primaryKey } from 'drizzle-orm/sqlite-core';
 
-export const user = sqliteTable('user', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull().unique(),
-  emailVerified: integer('email_verified', { mode: 'boolean' }).notNull(),
-  image: text('image'),
-  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+export const user = sqliteTable(
+  'user',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    email: text('email').notNull().unique(),
+    emailVerified: integer('email_verified', { mode: 'boolean' }).notNull(),
+    image: text('image'),
+    createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
 
-  // Additional fields for user profile
-  reputation: integer('reputation').notNull().default(0),
-  followersCount: integer('followers_count').notNull().default(0),
-  followingCount: integer('following_count').notNull().default(0),
+    // Additional fields for user profile
+    reputation: integer('reputation').notNull().default(0),
+    followersCount: integer('followers_count').notNull().default(0),
+    followingCount: integer('following_count').notNull().default(0),
 
-  // User level represented as integer but mapped to enum
-  level: integer('level').notNull().default(UserLevel.Regular).$type<UserLevel>(),
+    // User level represented as integer but mapped to enum
+    level: integer('level').notNull().default(UserLevel.Regular).$type<UserLevel>(),
 
-  // Storage usages
-  storageUsed: integer('storage_used').notNull().default(0),
+    // Storage usages
+    storageUsed: integer('storage_used').notNull().default(0),
 
-  // Moderation
-  isBanned: integer('is_banned', { mode: 'boolean' }).notNull().default(false),
-  banReason: text('ban_reason'),
-  banByUserId: text('ban_by_user_id'),
-}, table => ([
-  index('user_follower_idx').on(desc(table.followersCount), desc(table.followingCount), table.name)
-]));
+    // Moderation
+    isBanned: integer('is_banned', { mode: 'boolean' }).notNull().default(false),
+    banReason: text('ban_reason'),
+    banByUserId: text('ban_by_user_id'),
+  },
+  table => [
+    index('user_follower_idx').on(
+      desc(table.followersCount),
+      desc(table.followingCount),
+      table.name
+    ),
+  ]
+);
 
 export const session = sqliteTable('session', {
   id: text('id').primaryKey(),

--- a/src/server/services/users.ts
+++ b/src/server/services/users.ts
@@ -1,13 +1,15 @@
-"use server"
+'use server';
 
-import { getDB } from "@/libs/db"
-import * as schema from "@/libs/db/schema"
-import { desc, eq } from "drizzle-orm";
+import { getDB } from '@/libs/db';
+import * as schema from '@/libs/db/schema';
+import { desc, eq } from 'drizzle-orm';
 
 export async function getUserList(page: number, size: number) {
   const db = await getDB();
 
-  return await db.select().from(schema.user)
+  return await db
+    .select()
+    .from(schema.user)
     .innerJoin(schema.memberProfile, eq(schema.user.id, schema.memberProfile.userId))
     .limit(size)
     .offset((page - 1) * size)


### PR DESCRIPTION
**Summary of this PR (ref schema.ts):**

- Removes `banByUserId`, `banReason`, and `isBanned` fields from article queries.
- Adds `reviewStatus` and `reviewBy` fields to article queries.
- Updates the schema and related code to reflect these moderation changes, focusing on review-based moderation instead of ban-based flags for articles.
<img width="1128" height="944" alt="image" src="https://github.com/user-attachments/assets/7c187bb4-e1eb-4e8d-9f31-9fb679637fcd" />
Resolved 
<img width="1134" height="952" alt="image" src="https://github.com/user-attachments/assets/2ce0970b-966b-439c-b31a-c0c3c1da9a36" />

