### PR TITLE
feat:adjacent experiences from the same company

### DIFF
--- a/src/app/[username]/profile-experience.tsx
+++ b/src/app/[username]/profile-experience.tsx
@@ -4,41 +4,19 @@ import { ExperienceRecord, ProfileAiReviewFeedback } from '@/types';
 import { useProfileAiReview } from './profile-review-provider';
 import { Bot } from 'lucide-react';
 
-type GroupedResult<T, K extends keyof T, I extends string> = {
-  [P in K]: T[P];
-} & {
-  [P in I]: Array<Omit<T, K>>;
-};
-
-function groupDataByKey<T, K extends keyof T, I extends string>(
-  data: T[],
-  groupByKey: K,
-  itemsKey: I
-): Array<GroupedResult<T, K, I>> {
-  const groupedMap = data.reduce((acc, currentItem) => {
-    const groupValue = currentItem[groupByKey];
-    // Omit the key from original object
-    const { [groupByKey]: _, ...itemWithoutGroupKey } = currentItem;
-    if (!acc.has(groupValue)) {
-      acc.set(groupValue, {
-        [groupByKey]: groupValue,
-        [itemsKey]: [],
-      } as GroupedResult<T, K, I>);
-    }
-    acc.get(groupValue)![itemsKey].push(itemWithoutGroupKey);
-    return acc;
-  }, new Map<T[K], GroupedResult<T, K, I>>());
-
-  return Array.from(groupedMap.values()) as Array<GroupedResult<T, K, I>>;
-}
-
 export function ProfileExperienceListWithReview({
   experiences,
 }: {
   experiences: ExperienceRecord[];
 }) {
   const { feedback } = useProfileAiReview();
-  const groupedExp = groupDataByKey(experiences, 'companyName', 'items');
+
+  const disloyalExp: GroupedEXPWithGap<ExperienceRecord> = {
+    keyForSort: 'startYear',
+    keyForCheck: 'endYear',
+    sort: 'DESC',
+  };
+  const groupedExp = groupExpByKey(experiences, 'companyName', 'items', disloyalExp);
 
   return (
     <>
@@ -103,9 +81,11 @@ export function ProfileExperienceListWithReview({
                       <h3 className=" text-orange-400">{company.companyName}</h3>{' '}
                       <p className="text-sm text-muted-foreground">
                         <span>
-                          Working range: {company.items[company.items.length - 1].startYear}
+                          Working range: {Math.min(...company.items.map(exp => exp.startYear))}
                           &nbsp;-&nbsp;
-                          {company.items[0].endYear ? company.items[0].endYear : 'Present'}
+                          {company.items.map(exp => exp.endYear).includes(null)
+                            ? 'Present'
+                            : Math.max(...company.items.map(exp => exp.endYear ?? 0))}
                         </span>{' '}
                       </p>
                     </div>
@@ -158,3 +138,96 @@ const AIFeedBack = ({ feedback }: { feedback: ProfileAiReviewFeedback['experienc
     </div>
   );
 };
+
+type GroupedEXP<T, K extends keyof T, I extends string> = {
+  [P in K]: T[P];
+} & {
+  [P in I]: Array<Omit<T, K>>;
+};
+
+type GroupedEXPWithGap<T> =
+  | false
+  | { keyForSort: keyof T; keyForCheck: keyof T; sort: 'ASC' | 'DESC' };
+
+function groupExpByKey<T, K extends keyof T, I extends string>(
+  data: T[],
+  groupByKey: K,
+  itemsKey: I,
+  groupWithGap: GroupedEXPWithGap<T> = false
+): Array<GroupedEXP<T, K, I>> {
+  if (groupWithGap !== false && groupWithGap) {
+    const groupedMap = data.reduce((acc, currentItem) => {
+      const groupValue = currentItem[groupByKey];
+      const { [groupByKey]: _, ...itemWithoutGroupKey } = currentItem;
+
+      if (!acc.has(groupValue)) {
+        acc.set(groupValue, []);
+      }
+      // Store both (original item and item without group key) for later use
+      acc.get(groupValue)!.push({
+        original: currentItem,
+        omitted: itemWithoutGroupKey,
+      });
+      return acc;
+    }, new Map<T[K], Array<{ original: T; omitted: Omit<T, K> }>>());
+
+    const result: Array<GroupedEXP<T, K, I>> = [];
+
+    groupedMap.forEach((items, groupValue) => {
+      // sort exp to see gaps
+      items.sort(
+        (a, b) =>
+          new Date(a.original[groupWithGap.keyForSort] as any).getTime() -
+          new Date(b.original[groupWithGap.keyForSort] as any).getTime()
+      );
+
+      let currentGroup: Omit<T, K>[] = [];
+      let lastEndDate: Date | null = null;
+
+      items.forEach(item => {
+        const currentStartDate = new Date(item.original[groupWithGap.keyForSort] as any);
+
+        if (lastEndDate && currentStartDate.getTime() > lastEndDate.getTime()) {
+          // if found a gap, push current group and start new one
+          result.push({
+            [groupByKey]: groupValue,
+            [itemsKey]: currentGroup,
+          } as GroupedEXP<T, K, I>);
+          currentGroup = [];
+        }
+
+        currentGroup.push(item.omitted);
+        lastEndDate = new Date(item.original[groupWithGap.keyForCheck] as any);
+      });
+
+      result.push({
+        [groupByKey]: groupValue,
+        [itemsKey]: currentGroup,
+      } as GroupedEXP<T, K, I>);
+    });
+
+    // final sorting based on KeyForSort
+    return result.sort((a, b) => {
+      const startA = new Date((a[itemsKey] as any)[0][groupWithGap.keyForSort] as any).getTime();
+      const startB = new Date((b[itemsKey] as any)[0][groupWithGap.keyForSort] as any).getTime();
+
+      return groupWithGap.sort === 'ASC' ? startA - startB : startB - startA;
+    });
+  } else {
+    // simple grouping with sorting order of original data
+    const groupedMap = data.reduce((acc, currentItem) => {
+      const groupValue = currentItem[groupByKey];
+      const { [groupByKey]: _, ...itemWithoutGroupKey } = currentItem;
+      if (!acc.has(groupValue)) {
+        acc.set(groupValue, {
+          [groupByKey]: groupValue,
+          [itemsKey]: [],
+        } as GroupedEXP<T, K, I>);
+      }
+      acc.get(groupValue)![itemsKey].push(itemWithoutGroupKey);
+      return acc;
+    }, new Map<T[K], GroupedEXP<T, K, I>>());
+
+    return Array.from(groupedMap.values()) as Array<GroupedEXP<T, K, I>>;
+  }
+}

--- a/src/app/[username]/profile-experience.tsx
+++ b/src/app/[username]/profile-experience.tsx
@@ -3,6 +3,7 @@
 import { ExperienceRecord, ProfileAiReviewFeedback } from '@/types';
 import { useProfileAiReview } from './profile-review-provider';
 import { Bot } from 'lucide-react';
+import { groupExperiences } from '@/utils/experience';
 
 export function ProfileExperienceListWithReview({
   experiences,
@@ -129,63 +130,3 @@ const AIFeedBack = ({ feedback }: { feedback: ProfileAiReviewFeedback['experienc
     </div>
   );
 };
-
-interface ExperienceRecordGroup {
-  companyName: ExperienceRecord['companyName'];
-  companyLogo: ExperienceRecord['companyLogo'];
-  startYear: ExperienceRecord['startYear'];
-  endYear: ExperienceRecord['endYear'];
-  items: ExperienceRecord[];
-}
-/**
- * Groups an array of experience records by company name, merge continuous
- * periods of employment and separate periods with time gaps.
- * @param experiences An array of `ExperienceRecord` objects.
- * @returns An array of `ExperienceRecordGroup` objects sorted `DESC` by `startYear` property.
- */
-export function groupExperiences(experiences: ExperienceRecord[]): ExperienceRecordGroup[] {
-  if (!experiences || experiences.length === 0) {
-    return [];
-  }
-  const sortedExperiences = [...experiences];
-
-  // Sort by company name & start year
-  sortedExperiences.sort(
-    (a, b) => a.companyName.localeCompare(b.companyName) || a.startYear - b.startYear
-  );
-
-  const grouped = sortedExperiences.reduce<ExperienceRecordGroup[]>((acc, exp) => {
-    // Get most recent created group
-    const lastGroup = acc.length > 0 ? acc[acc.length - 1] : null;
-
-    // Conditions (same company & continuous employment period)
-    const isSameCompany = lastGroup && lastGroup.companyName === exp.companyName;
-    const isContinuous =
-      lastGroup && (lastGroup.endYear === null || exp.startYear <= lastGroup.endYear);
-
-    if (isSameCompany && isContinuous) {
-      // Merge to the existing group
-      lastGroup.items.push(exp);
-
-      if (exp.endYear === null) {
-        lastGroup.endYear = null;
-      } else if (lastGroup.endYear !== null) {
-        lastGroup.endYear = Math.max(lastGroup.endYear, exp.endYear);
-      }
-    } else {
-      // Add to a new group
-      acc.push({
-        companyName: exp.companyName,
-        companyLogo: exp.companyLogo,
-        startYear: exp.startYear,
-        endYear: exp.endYear,
-        items: [exp],
-      });
-    }
-
-    return acc;
-  }, []);
-
-  // Re-sort the final groups startYear (DESC order)
-  return grouped.sort((a, b) => b.startYear - a.startYear);
-}

--- a/src/app/[username]/profile-experience.tsx
+++ b/src/app/[username]/profile-experience.tsx
@@ -1,8 +1,36 @@
 'use client';
 
-import { ExperienceRecord } from '@/types';
+import { ExperienceRecord, ProfileAiReviewFeedback } from '@/types';
 import { useProfileAiReview } from './profile-review-provider';
 import { Bot } from 'lucide-react';
+
+type GroupedResult<T, K extends keyof T, I extends string> = {
+  [P in K]: T[P];
+} & {
+  [P in I]: Array<Omit<T, K>>;
+};
+
+function groupDataByKey<T, K extends keyof T, I extends string>(
+  data: T[],
+  groupByKey: K,
+  itemsKey: I
+): Array<GroupedResult<T, K, I>> {
+  const groupedMap = data.reduce((acc, currentItem) => {
+    const groupValue = currentItem[groupByKey];
+    // Omit the key from original object
+    const { [groupByKey]: _, ...itemWithoutGroupKey } = currentItem;
+    if (!acc.has(groupValue)) {
+      acc.set(groupValue, {
+        [groupByKey]: groupValue,
+        [itemsKey]: [],
+      } as GroupedResult<T, K, I>);
+    }
+    acc.get(groupValue)![itemsKey].push(itemWithoutGroupKey);
+    return acc;
+  }, new Map<T[K], GroupedResult<T, K, I>>());
+
+  return Array.from(groupedMap.values()) as Array<GroupedResult<T, K, I>>;
+}
 
 export function ProfileExperienceListWithReview({
   experiences,
@@ -10,6 +38,7 @@ export function ProfileExperienceListWithReview({
   experiences: ExperienceRecord[];
 }) {
   const { feedback } = useProfileAiReview();
+  const groupedExp = groupDataByKey(experiences, 'companyName', 'items');
 
   return (
     <>
@@ -31,44 +60,79 @@ export function ProfileExperienceListWithReview({
         </div>
       )}
 
-      <div className="mt-6 flex flex-col gap-4">
-        {experiences.map((exp, index) => {
-          const aiFeedback = feedback?.experiences.find(experience => experience.id === exp.id);
-
+      <div className="flex flex-col gap-4 mt-6">
+        {groupedExp.map((company, idx) => {
           return (
-            <div key={index} className="flex gap-2">
+            <div key={idx} className="flex gap-2">
+              {/* company logo */}
               <div className="bg-card border h-12 w-12 rounded shrink-0 flex items-center justify-center text-orange-400 font-bold">
-                {exp.companyName
+                {company.companyName
                   .split(' ')
                   .slice(0, 2)
                   .map(word => word.charAt(0).toUpperCase())
                   .join('')}
               </div>
-              <div>
-                <h3 className="text-sm font-semibold">{exp.role}</h3>{' '}
-                <p className="text-sm text-muted-foreground">
-                  <span className="text-orange-400">{exp.companyName}</span> ({exp.startYear} -{' '}
-                  {exp.endYear ? exp.endYear : 'Present'})
-                </p>
-                <p className="text-sm text-muted-foreground whitespace-pre-line">
-                  {exp.description}
-                </p>
-                {aiFeedback && (
-                  <div className="bg-card border p-2 text-sm my-2 rounded flex flex-col gap-1">
-                    <h2 className="font-semibold text-blue-800 dark:text-blue-400 flex items-center gap-2">
-                      <Bot />
-                      AI Feedback
-                    </h2>
-                    <p>{aiFeedback.feedback}</p>
-                    {aiFeedback.suggestion && (
-                      <>
-                        <strong>Suggestion</strong>
-                        <p>{aiFeedback.suggestion}</p>
-                      </>
-                    )}
+
+              {/* experience list (single) */}
+              {company.items.length <= 1 &&
+                company.items.map((exp, index) => {
+                  const aiFeedback = feedback?.experiences.find(
+                    experience => experience.id === exp.id
+                  );
+                  return (
+                    <div key={index}>
+                      <h3 className="text-sm font-semibold">{exp.role}</h3>{' '}
+                      <p className="text-sm text-muted-foreground">
+                        <span className="text-orange-400">{company.companyName}</span> (
+                        {exp.startYear}&nbsp;-&nbsp;{exp.endYear ? exp.endYear : 'Present'})
+                      </p>
+                      <p className="text-sm text-muted-foreground whitespace-pre-line">
+                        {exp.description}
+                      </p>
+                      {aiFeedback && <AIFeedBack feedback={aiFeedback} />}
+                    </div>
+                  );
+                })}
+
+              {/* experience list (multiple) */}
+              {company.items.length > 1 && (
+                <>
+                  <div className="flex flex-col gap-3">
+                    {/* company name & date range */}
+                    <div>
+                      <h3 className=" text-orange-400">{company.companyName}</h3>{' '}
+                      <p className="text-sm text-muted-foreground">
+                        <span>
+                          Working range: {company.items[company.items.length - 1].startYear}
+                          &nbsp;-&nbsp;
+                          {company.items[0].endYear ? company.items[0].endYear : 'Present'}
+                        </span>{' '}
+                      </p>
+                    </div>
+
+                    {/* each experience */}
+                    {company.items.map((exp, index) => {
+                      const aiFeedback = feedback?.experiences.find(
+                        experience => experience.id === exp.id
+                      );
+                      return (
+                        <div key={index} className="experience-item">
+                          <h3 className="text-sm font-semibold">{exp.role}</h3>{' '}
+                          <p className="text-sm text-muted-foreground">
+                            <span>
+                              {exp.startYear}&nbsp;-&nbsp;{exp.endYear ? exp.endYear : 'Present'}
+                            </span>
+                          </p>
+                          <p className="text-sm text-muted-foreground whitespace-pre-line">
+                            {exp.description}
+                          </p>
+                          {aiFeedback && <AIFeedBack feedback={aiFeedback} />}
+                        </div>
+                      );
+                    })}
                   </div>
-                )}
-              </div>
+                </>
+              )}
             </div>
           );
         })}
@@ -76,3 +140,21 @@ export function ProfileExperienceListWithReview({
     </>
   );
 }
+
+const AIFeedBack = ({ feedback }: { feedback: ProfileAiReviewFeedback['experiences'][0] }) => {
+  return (
+    <div className="bg-card border p-2 text-sm my-2 rounded flex flex-col gap-1">
+      <h2 className="font-semibold text-blue-800 dark:text-blue-400 flex items-center gap-2">
+        <Bot />
+        AI Feedback
+      </h2>
+      <p>{feedback.feedback}</p>
+      {feedback.suggestion && (
+        <>
+          <strong>Suggestion</strong>
+          <p>{feedback.suggestion}</p>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/app/[username]/profile-experience.tsx
+++ b/src/app/[username]/profile-experience.tsx
@@ -206,7 +206,19 @@ function groupExpByKey<T, K extends keyof T, I extends string>(
       } as GroupedEXP<T, K, I>);
     });
 
-    // final sorting based on KeyForSort
+    // sorting [itemsKey]'s items
+    result.forEach(res => {
+      return (
+        res[itemsKey].length > 1 &&
+        res[itemsKey].sort((a, b) => {
+          const startA = new Date(a[groupWithGap.keyForSort as keyof typeof a] as any).getTime();
+          const startB = new Date(b[groupWithGap.keyForSort as keyof typeof b] as any).getTime();
+          return groupWithGap.sort === 'ASC' ? startA - startB : startB - startA;
+        })
+      );
+    });
+
+    // sorting [groupByKey]'s items
     return result.sort((a, b) => {
       const startA = new Date((a[itemsKey] as any)[0][groupWithGap.keyForSort] as any).getTime();
       const startB = new Date((b[itemsKey] as any)[0][groupWithGap.keyForSort] as any).getTime();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -243,3 +243,17 @@ based on light & dark themes */
 .markdown hr {
   @apply border-t border-gray-300 dark:border-gray-600 my-4;
 }
+
+/* Experience Item Style */
+.experience-item {
+  @apply isolate relative;
+
+  /* dot */
+  &::after {
+    @apply content-[''] absolute w-2 h-2 bg-orange-400 rounded-full mt-1.5 top-0 -left-9;
+  }
+  /* vertical line */
+  &::before:not(:last-child) {
+    @apply box-border absolute content-[''] h-[calc(100%-theme(spacing.4))] w-0.5 bg-orange-400/30 mt-6 top-0 -left-[2.075rem];
+  }
+}

--- a/src/utils/experience.test.ts
+++ b/src/utils/experience.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { sortExperience } from './experience';
+import { sortExperience, groupExperiences } from './experience';
 import { ExperienceRecord } from '@/types';
 
 test('ordering working experience with present', () => {
@@ -32,6 +32,80 @@ test('ordering working experience with all past', () => {
   expect(exp[2].companyName).toEqual('Company A'); // Third most recent past experience
   expect(exp[3].companyName).toEqual('Company B'); // Fourth most recent past experience
   expect(exp[4].companyName).toEqual('Company D'); // Oldest past experience
+});
+
+// groupExperiences tests
+test('ordering working experience with present', () => {
+  const exp = groupExperiences([
+    e('Company A', 2023, null),
+    e('Company C', 2022, null),
+    e('Company D', 2019, 2020),
+    e('Company B', 2018, null),
+    e('Company E', 2016, 2017),
+  ]);
+
+  expect(exp[0].companyName).toEqual('Company A'); // Most recent present experience
+  expect(exp[1].companyName).toEqual('Company C'); // Second most recent present experience
+  expect(exp[2].companyName).toEqual('Company B'); // Third most recent present experience
+  expect(exp[3].companyName).toEqual('Company D'); // Second most recent past experience
+  expect(exp[4].companyName).toEqual('Company E'); // Oldest past experience
+});
+
+test('ordering working experience with all past', () => {
+  const exp = groupExperiences([
+    e('Company A', 2022, 2023),
+    e('Company B', 2019, 2020),
+    e('Company C', 2017, 2021),
+    e('Company D', 2018, 2020),
+    e('Company E', 2021, 2022),
+  ]);
+
+  expect(exp[0].companyName).toEqual('Company A'); // Most recent past experience
+  expect(exp[1].companyName).toEqual('Company E'); // Second most recent past experience
+  expect(exp[2].companyName).toEqual('Company B'); // Third most recent past experience
+  expect(exp[3].companyName).toEqual('Company D'); // Fourth most recent past experience
+  expect(exp[4].companyName).toEqual('Company C'); // Oldest past experience
+});
+
+test('ordering and grouping working experience with present & past (non-consecutive)', () => {
+  const exp = groupExperiences([
+    e('Company A', 2022, 2023),
+    e('Company A', 2023, null),
+    e('Company B', 2017, 2021),
+    e('Company C', 2018, 2020),
+    e('Company C', 2021, null),
+  ]);
+
+  // grouping experiences with latest start year and null end year (present)
+  expect(exp[0].companyName).toEqual('Company A');
+  expect(exp[0].items.length).toEqual(2); // 2 items in the group
+
+  // no getting grouped by most recent experience start year is bigger than
+  // second most recent experience end year
+  expect(exp[1].companyName).toEqual('Company C');
+  expect(exp[2].companyName).toEqual('Company C');
+
+  expect(exp[3].companyName).toEqual('Company B'); // Oldest past experience
+});
+
+test('ordering and grouping working experience with present & past (consecutive)', () => {
+  const exp = groupExperiences([
+    e('Company A', 2022, 2023),
+    e('Company A', 2023, null),
+    e('Company B', 2017, 2021),
+    e('Company C', 2018, 2020),
+    e('Company C', 2020, null),
+    e('Company C', 2022, null),
+  ]);
+
+  // grouping experiences with latest start year and null end year (present)
+  expect(exp[0].companyName).toEqual('Company A');
+  expect(exp[0].items.length).toEqual(2); // 2 items in the group
+
+  expect(exp[1].companyName).toEqual('Company C');
+  expect(exp[1].items.length).toEqual(3); // 3 items in the group
+
+  expect(exp[2].companyName).toEqual('Company B'); // Oldest past experience
 });
 
 /**

--- a/src/utils/experience.ts
+++ b/src/utils/experience.ts
@@ -1,5 +1,13 @@
 import type { ExperienceRecord } from '@/types';
 
+interface ExperienceRecordGroup {
+  companyName: ExperienceRecord['companyName'];
+  companyLogo: ExperienceRecord['companyLogo'];
+  startYear: ExperienceRecord['startYear'];
+  endYear: ExperienceRecord['endYear'];
+  items: ExperienceRecord[];
+}
+
 /**
  * Sorting experience record by end date in descending order.
  * If end date is NULL, it means it is present, so it should be sorted to the top.
@@ -19,5 +27,68 @@ export function sortExperience(experiences: ExperienceRecord[]): ExperienceRecor
     if (endA > endB) return -1; // a comes before b
 
     return b.startYear - a.startYear; // Sort by start date in descending order
+  });
+}
+
+/**
+ * Groups an array of experience records by company name, merge continuous
+ * periods of employment and separate periods with time gaps.
+ * @param experiences An array of `ExperienceRecord` objects.
+ * @returns An array of `ExperienceRecordGroup` objects sorted `DESC` by `startYear` if `endYear` is null.
+ */
+export function groupExperiences(experiences: ExperienceRecord[]): ExperienceRecordGroup[] {
+  if (!experiences || experiences.length === 0) {
+    return [];
+  }
+  const sortedExperiences = [...experiences];
+
+  // Sort by company name & start year
+  sortedExperiences.sort(
+    (a, b) => a.companyName.localeCompare(b.companyName) || a.startYear - b.startYear
+  );
+
+  const grouped = sortedExperiences.reduce<ExperienceRecordGroup[]>((acc, exp) => {
+    // Get most recent created group
+    const lastGroup = acc.length > 0 ? acc[acc.length - 1] : null;
+
+    // Conditions (same company & continuous employment period)
+    const isSameCompany = lastGroup && lastGroup.companyName === exp.companyName;
+    const isContinuous =
+      lastGroup && (lastGroup.endYear === null || exp.startYear <= lastGroup.endYear);
+
+    if (isSameCompany && isContinuous) {
+      // Merge to the existing group
+      lastGroup.items.push(exp);
+
+      if (exp.endYear === null) {
+        lastGroup.endYear = null;
+      } else if (lastGroup.endYear !== null) {
+        lastGroup.endYear = Math.max(lastGroup.endYear, exp.endYear);
+      }
+    } else {
+      // Add to a new group
+      acc.push({
+        companyName: exp.companyName,
+        companyLogo: exp.companyLogo,
+        startYear: exp.startYear,
+        endYear: exp.endYear,
+        items: [exp],
+      });
+    }
+
+    return acc;
+  }, []);
+
+  // Re-sort the final groups startYear only endYear is null (DESC order)
+  return grouped.sort((a, b) => {
+    if (a.endYear === null && b.endYear === null) {
+      return b.startYear - a.startYear;
+    } else if (a.endYear === null) {
+      return -1;
+    } else if (b.endYear === null) {
+      return 1;
+    } else {
+      return b.startYear - a.startYear;
+    }
   });
 }


### PR DESCRIPTION
## Proposed Changes #115 

  - added `groupExpByKey` function for grouping experience based on keys _`(companyName)`_.
  - added options to group all _(non-consecutive-exp)_ & group with gap _(only-consecutive-exp)_.
  - added `.experience-item` CSS class for styling.
 
```typescript
// group all
const groupedExp = groupExpByKey(experiences, 'companyName', 'items');
// group with gap
const groupedExp = groupExpByKey(experiences, 'companyName', 'items', {
    keyForSort: 'startYear',
    keyForCheck: 'endYear',
    sort: 'DESC',
});
``` 
---

### Outputs (group all & group with gap)
<p>
<img width="390" title="group all" src="https://github.com/user-attachments/assets/c794771d-7c2e-4330-a4d9-82a2103fa0e6" />
<img width="390" title="group with gap" src="https://github.com/user-attachments/assets/de5c5e35-ec46-45df-836f-ec87e97a1938" />
</p>

---
As always, I'm happy to get corrected by bong bong, Thanks <3