### PR TITLE
Fix redirect issue after alias update

### DIFF
--- a/src/server/actions/users.ts
+++ b/src/server/actions/users.ts
@@ -7,6 +7,7 @@ import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { sortExperience } from '@/utils/experience';
 import z from 'zod';
 import { ProfileAiReviewFeedback } from '@/types';
+import { revalidatePath } from 'next/cache';
 
 export const getUserAction = withAuthAction(async ({ user }) => {
   return user;
@@ -76,7 +77,7 @@ export const updateUserAliasAction = withAuthAction(
         message: 'Failed to update alias. Please try again later.',
       };
     }
-
+    revalidatePath(`/@${normalizedAlias}`);
     return {
       success: true,
       message: 'Alias updated successfully.',
@@ -176,17 +177,9 @@ export const updateUserProfileAction = withAuthAction(
           .where(eq(schema.memberProfile.userId, user.id)),
       ]);
 
-      const updatedProfile = await db.query.memberProfile.findFirst({
-        where: eq(schema.memberProfile.userId, user.id),
-        columns: {
-          alias: true,
-        },
-      });
-
       return {
         success: true,
-        message: 'Profile updated successfully.',
-        alias: updatedProfile?.alias,
+        message: 'Profile updated successfully.'
       };
     } catch (error) {
       console.error('Failed to update profile:', error);


### PR DESCRIPTION
### Summary
Fixes an issue where the app redirected to the old alias after updating a user's profile.

### Problem
When a user changes their alias (username), the system stores the new alias correctly.
However, if the user immediately updates other profile information afterward,
the redirect logic still uses the old alias value, causing a 404 "Not Found" error.

### Fix
The redirect logic now correctly references the updated alias from the latest user data,
ensuring the user is redirected to the correct (new) profile URL after saving changes.

### Steps to Reproduce
1. Go to /profile/setup/alias
2. Change alias (e.g., from `bunheng` to `benghun`).
3. Save changes.
4. Go to /profile/setup/detail
5. Update another field (e.g., Name or Professional Title).
6. After saving, the app redirects to `/profile/bunheng` (old alias) instead of `/profile/benghun`.

### Result
✅ Redirect now correctly uses the new alias.