### PR TITLE
fix: remove trailing backtick typo in showcase header component

### DIFF
--- a/src/app/showcase/[alias]/header.tsx
+++ b/src/app/showcase/[alias]/header.tsx
@@ -37,7 +37,7 @@ export function ShowcaseHeader() {
     <>
       {editMode === 'tagline' && <DialogEditTagline onClose={handleCloseDialog} />}
       {editMode === 'website' && <DialogWebsiteLink type="website" onClose={handleCloseDialog} />}
-      {editMode === 'github' && <DialogWebsiteLink type="github" onClose={handleCloseDialog} />}`
+      {editMode === 'github' && <DialogWebsiteLink type="github" onClose={handleCloseDialog} />}
       <div className="flex gap-4 pt-2 pb-4 px-6">
         <ShowcaseLogo />
         <div className="flex flex-col justify-center">


### PR DESCRIPTION
Closes #{issue key}

## Proposed Changes

  - Remove trailing backtick typo in showcase header component
<img width="942" height="347" alt="bug" src="https://github.com/user-attachments/assets/58e159bb-b876-4c25-8ea6-231cdd8fb955" />

  -
  -
